### PR TITLE
Add two new supported content types

### DIFF
--- a/background.js
+++ b/background.js
@@ -9,6 +9,8 @@ chrome.webRequest.onHeadersReceived.addListener(
     let matched = [
       'application/json',
       'application/x-javascript',
+      'application/hal+json',
+      'application/vnd.error+json'
       'text/javascript',
       'text/x-javascript',
       'text/x-json',


### PR DESCRIPTION
I added two new content-types so that they are also rendered as json:
- [`hal+json`](http://stateless.co/hal_specification.html) is just plain old JSON but with standarized schema
- [`vnd.error+json`](https://github.com/blongden/vnd.error) is also just a standarization of the JSON schema