### PR TITLE
Add new supported content type

### DIFF
--- a/data/file.js
+++ b/data/file.js
@@ -4,6 +4,7 @@ const type = document.contentType;
 const json = [
   'application/json',
   'application/hal+json',
+  'application/vnd.api+json',
   'application/vnd.error+json',
   'text/x-json',
   'text/plain'


### PR DESCRIPTION
Hi, I added a new content-type to also rendered as json:
  - [vnd.api+json](https://jsonapi.org/). Is a standarization of the JSON schema following the [JSON:API](https://jsonapi.org/) specification

Thank you for this wonderful extension!