### PR TITLE
fix: use the more-targeted `querySelector` to get JSON contents to parse

### DIFF
--- a/data/view/inject.js
+++ b/data/view/inject.js
@@ -118,7 +118,7 @@ function buttons() {
 }
 
 function render() {
-  const content = document.body.textContent.trim();
+  const content = document.querySelector("body > pre").innerText;
 
   chrome.storage.local.get({
     'use-big-number': true,


### PR DESCRIPTION
Fixes #16.